### PR TITLE
Bug fix from Kate Zhang to compile gbbepx2netcdf on Hera

### DIFF
--- a/process-obs/FV3/gbbepx2netcdf/mk-hera.sh
+++ b/process-obs/FV3/gbbepx2netcdf/mk-hera.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 set -ue
-module load intel netcdf szip hdf5
+module load intel/19.0.5.281 netcdf szip hdf5
 set -x
 
 fflags=$( nf-config --fflags )


### PR DESCRIPTION
The "intel" module now requires a version number. This fix comes from Kate Zhang.