### PR TITLE
Update prep chem to fix bug in exglobal_prep_chem.sh

### DIFF
--- a/workflow/emc-global/scripts/exglobal_prep_chem.sh
+++ b/workflow/emc-global/scripts/exglobal_prep_chem.sh
@@ -48,7 +48,7 @@
 # The FIXchem:
 #  Gyre/Surge/Venus: /gpfs/dell2/emc/obsproc/noscrub/Samuel.Trahan/prep_chem/FIXchem/
 
-set -xue
+set -x
 
 if [[ ! -d "$COMOUTchem" ]] ; then
     mkdir -p "$COMOUTchem"


### PR DESCRIPTION
The prep chem job script is updated so that the script does not fail and continues to run if no gbbepx data is available.

This PR resolves issue #9.